### PR TITLE
[Feat] #29 - 일반 사용자 수정, 탈퇴 기능 구현

### DIFF
--- a/DDL/wooga_db_script.sql
+++ b/DDL/wooga_db_script.sql
@@ -225,7 +225,7 @@ CREATE TABLE if NOT EXISTS UserInfoUpdate (
     user_update_after_phone_number VARCHAR(255) NULL,
     user_update_previous_email VARCHAR(255) NULL,
     user_update_after_email VARCHAR(255) NULL,
-    user_id	VARCHAR(255) NOT NULL,
+    user_id	VARCHAR(255) NOT NULL UNIQUE,
     PRIMARY KEY(user_update_id),
     FOREIGN KEY(user_id) REFERENCES User(user_id)
 )ENGINE=INNODB;

--- a/DML/user/user_info_update.sql
+++ b/DML/user/user_info_update.sql
@@ -1,0 +1,8 @@
+-- 비밀번호와 전화번호만 수정
+CALL UpdateUserInfo('user01', '1234', NULL, '010-9999-9999', NULL);
+
+CALL UpdateUserInfo('user01', NULL, NULL, NULL, '경기도 용인시');
+
+
+select * from User;
+select * from UserInfoUpdate;

--- a/DML/user/user_info_update.sql
+++ b/DML/user/user_info_update.sql
@@ -1,8 +1,9 @@
 -- 비밀번호와 전화번호만 수정
 CALL UpdateUserInfo('user01', '1234', NULL, '010-9999-9999', NULL);
-
 CALL UpdateUserInfo('user01', NULL, NULL, NULL, '경기도 용인시');
 
 
 select * from User;
 select * from UserInfoUpdate;
+
+show triggers;

--- a/DML/user/user_info_update_procedure.sql
+++ b/DML/user/user_info_update_procedure.sql
@@ -1,0 +1,46 @@
+--
+
+DELIMITER //
+
+CREATE PROCEDURE UpdateUserInfo (
+    IN p_user_id VARCHAR(255),
+    IN p_pwd VARCHAR(255),
+    IN p_email VARCHAR(255),
+    IN p_phone_number VARCHAR(255),
+    IN p_address VARCHAR(255)
+)
+BEGIN
+    -- 비밀번호 변경
+    IF p_pwd IS NOT NULL THEN
+    UPDATE User
+    SET pwd = p_pwd,
+        last_pwd_change_date = CURRENT_TIMESTAMP
+    WHERE user_id = p_user_id;
+    END IF;
+
+    -- 이메일 변경
+    IF p_email IS NOT NULL THEN
+    UPDATE User
+    SET email = p_email
+    WHERE user_id = p_user_id;
+    END IF;
+
+    -- 전화번호 변경
+    IF p_phone_number IS NOT NULL THEN
+    UPDATE User
+    SET phone_number = p_phone_number
+    WHERE user_id = p_user_id;
+    END IF;
+
+    -- 주소 변경
+    IF p_address IS NOT NULL THEN
+    UPDATE User
+    SET address = p_address
+    WHERE user_id = p_user_id;
+    END IF;
+
+    SELECT '회원 정보가 수정되었습니다.' AS result;
+END;
+//
+
+DELIMITER ;

--- a/DML/user/user_info_update_procedure.sql
+++ b/DML/user/user_info_update_procedure.sql
@@ -1,8 +1,7 @@
---
-
 DELIMITER //
 
-CREATE PROCEDURE UpdateUserInfo (
+DROP PROCEDURE IF EXISTS UpdateUserInfo;
+CREATE PROCEDURE IF NOT EXISTS UpdateUserInfo (
     IN p_user_id VARCHAR(255),
     IN p_pwd VARCHAR(255),
     IN p_email VARCHAR(255),

--- a/DML/user/user_info_update_trigger.sql
+++ b/DML/user/user_info_update_trigger.sql
@@ -1,0 +1,27 @@
+DELIMITER //
+
+CREATE TRIGGER trg_after_user_update
+    AFTER UPDATE ON User
+    FOR EACH ROW
+BEGIN
+    -- 변경된 필드에 대해서만 UPDATE 수행
+    UPDATE UserInfoUpdate
+    SET
+        user_update_at = CURRENT_TIMESTAMP,
+
+        user_update_previous_pwd = IF(OLD.pwd != NEW.pwd, OLD.pwd, user_update_previous_pwd),
+        user_update_after_pwd = IF(OLD.pwd != NEW.pwd, NEW.pwd, user_update_after_pwd),
+
+        user_update_previous_email = IF(OLD.email != NEW.email, OLD.email, user_update_previous_email),
+        user_update_after_email = IF(OLD.email != NEW.email, NEW.email, user_update_after_email),
+
+        user_update_previous_phone_number = IF(OLD.phone_number != NEW.phone_number, OLD.phone_number, user_update_previous_phone_number),
+        user_update_after_phone_number = IF(OLD.phone_number != NEW.phone_number, NEW.phone_number, user_update_after_phone_number),
+
+        user_update_previous_address = IF(OLD.address != NEW.address, OLD.address, user_update_previous_address),
+        user_update_after_address = IF(OLD.address != NEW.address, NEW.address, user_update_after_address)
+    WHERE user_id = NEW.user_id;
+END;
+//
+
+DELIMITER ;

--- a/DML/user/user_resign.sql
+++ b/DML/user/user_resign.sql
@@ -1,0 +1,6 @@
+UPDATE User
+SET user_state = 'RESIGN',
+    resign_date = CURRENT_TIMESTAMP
+WHERE user_id = 'user01';
+
+select * from user;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #29 

## 📝작업 내용

일반 사용자 정보 수정 기능과 탈퇴 기능 구현했습니다 ~~

**정보 수정**

- `UpdateUserInfo` 프로시저를 통해 전달받은 항목(비밀번호, 이메일, 전화번호, 주소)의 NULL 여부를 판단하여 변경된 항목만 UPDATE
- 사용자 정보가 수정될 경우, 트리거 `trg_after_user_update`를 통해 자동으로 `UserInfoUpdate` 테이블에 변경 이력 기록
- `UserInfoUpdate`는 사용자당 1행만 유지하는 구조이며, 기존 값을 덮어쓰는 UPDATE 방식 사용
- 트리거 내에서 OLD vs NEW 값을 비교하여 변경된 필드만 기록
- User 테이블의 `user_update_at` 필드도 함께 갱신

||사진|
|--|--|
|User 변경 전|<img width="1359" height="61" alt="image" src="https://github.com/user-attachments/assets/32159fc5-d7c3-4219-8738-028dc1023c32" />|
|User 변경 후|<img width="1371" height="60" alt="image" src="https://github.com/user-attachments/assets/1d3d07d7-e88a-4e58-8655-779cba9e6a19" />|
|개인정보변경이력 추가됨|<img width="1375" height="237" alt="image" src="https://github.com/user-attachments/assets/19be53b2-761d-47d3-9c7e-7975923e3daf" />|

> **주의사항 !!**
> 개인정보 변경 이력(UserInfoUpdate)은 회원가입 시 자동으로 생성되도록 트리거가 설정되어 있습니다.
> 따라서 초기 세팅 시에는 아래 순서대로 실행해야 정상적으로 동작합니다:
> 1. DB 스크립트 실행 (테이블 생성)
> 2. 트리거 실행 (생성)
> 3. 더미 회원 데이터 추가 → 이때 개인정보 변경이력 행도 자동 생성됨

**회원 탈퇴 (소프트 삭제) & 휴면 계정 전환 **

- User 테이블 user_state를 'RESIGN'으로 변경하고 resign_date에 현재 시간 저장
- 물리적인 삭제가 아닌 소프트 삭제 방식 적용

<img width="622" height="108" alt="image" src="https://github.com/user-attachments/assets/ce259d92-d0ae-4f52-bc08-da96a3886696" />
